### PR TITLE
fix(idempotency-key): fix the "Idempotency-Key" header format

### DIFF
--- a/src/engines/ethereum_ledger/eth_engine.rs
+++ b/src/engines/ethereum_ledger/eth_engine.rs
@@ -536,7 +536,12 @@ where
             .push("accounts")
             .push(&account_id.clone())
             .push("settlements");
-        debug!("Making POST to {:?} {:?} about {:?}", url, amount, tx_hash);
+        debug!(
+            "Making POST to {:?} {:?} about {:?}",
+            url,
+            amount,
+            format!("{:?}", tx_hash)
+        );
 
         let account_id_clone = account_id.clone();
         let amount_clone = amount.clone();
@@ -546,7 +551,7 @@ where
             let amount = amount.clone();
             client
                 .post(url.as_ref())
-                .header("Idempotency-Key", tx_hash.to_string())
+                .header("Idempotency-Key", format!("{:?}", tx_hash))
                 .json(&json!(Quantity::new(amount.clone(), engine_scale)))
                 .send()
                 .map_err(move |err| {


### PR DESCRIPTION
Now the "Idempotency-Key" header value is like "0xb7ef…375a" which causes a conversion error in
warp header parser and it makes settlements fail because now the API moved to `warp`.

So I fixed to send a fully described hash like
"0xb7eff4efea4f34ece7aacd40f061ede8ac3ff84dc1257ddd2c15aec17e63375a".