### PR TITLE
ci(releases): auto-publish binaries and docker images of ilp-settlement-ethereum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,10 @@ jobs:
           # builds release profile images to be released
           name: Build Docker Images
           command: |
-            export DOCKER_IMAGE_TAG=$(./.circleci/release/get_docker_image_tag.sh interledger-settlement-engines ${CIRCLE_TAG})
-            docker/docker-build.sh settlement-engines
+            if [ "${CIRCLE_BRANCH}" = "master" ] || [[ "${CIRCLE_TAG}" =~ ^ilp-settlement-ethereum- ]]; then
+              export DOCKER_IMAGE_TAG=$(./.circleci/release/get_docker_image_tag.sh ethereum-engine ${CIRCLE_TAG})
+              docker/docker-build.sh ilp-settlement-ethereum
+            fi
           environment:
             PROFILE: "release"
       - run:
@@ -85,9 +87,11 @@ jobs:
           command: |
             echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
 
-            DOCKER_IMAGE_TAG=$(./.circleci/release/get_docker_image_tag.sh interledger-settlement-engines ${CIRCLE_TAG})
-            echo "Pushing docker image of tag: interledgerrs/settlement-engines:${DOCKER_IMAGE_TAG}"
-            docker push interledgerrs/settlement-engines:${DOCKER_IMAGE_TAG}
+            if [ "${CIRCLE_BRANCH}" = "master" ] || [[ "${CIRCLE_TAG}" =~ ^ilp-settlement-ethereum- ]]; then
+              DOCKER_IMAGE_TAG=$(./.circleci/release/get_docker_image_tag.sh ethereum-engine ${CIRCLE_TAG})
+              echo "Pushing docker image of tag: interledgerrs/ilp-settlement-ethereum:${DOCKER_IMAGE_TAG}"
+              docker push interledgerrs/ilp-settlement-ethereum:${DOCKER_IMAGE_TAG}
+            fi
   build-release-binary-linux:
     docker:
       - image: circleci/rust
@@ -129,7 +133,7 @@ jobs:
           command: |
             crate_name=$(./.circleci/release/get_crate_name.sh ${CIRCLE_TAG})
             printf "Building crate_name: %s, tag: %s\n" "${crate_name}" "${CIRCLE_TAG}"
-            cargo build --release --features "ethereum" --package "${crate_name}" --bin "${crate_name}" --target x86_64-apple-darwin
+            cargo build --release --package "${crate_name}" --bin "${crate_name}" --target x86_64-apple-darwin
             mkdir -p /tmp/release-builds/x86_64-apple-darwin
             cp target/x86_64-apple-darwin/release/${crate_name} /tmp/release-builds/x86_64-apple-darwin/${crate_name}
       - persist_to_workspace:
@@ -211,7 +215,7 @@ jobs:
 
             # latest release, only if on the master branch
             # tag the current commit as (crate_name)-latest, and release it
-            if [ "${CIRCLE_TAG}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
               tag_name="${crate_name}-latest"
               LOG_DIR=logs/${tag_name} ./.circleci/release/github_tag.sh \
                 ${tag_name} \
@@ -247,7 +251,7 @@ workflows:
                 - master
             tags:
               only: # whatever tagged binary crates
-                - /^(interledger-settlement-engines-|v).*$/
+                - /^(ilp-settlement-ethereum-|v).*$/
           requires:
             - build
       - build-release-binary-linux:
@@ -257,7 +261,7 @@ workflows:
                 - /.*/
             tags:
               only: # whatever tagged binary crates
-                - /^(interledger-settlement-engines-|v).*$/
+                - /^(ilp-settlement-ethereum-|v).*$/
           requires:
             - build
       - build-release-binary-darwin:
@@ -267,7 +271,7 @@ workflows:
                 - /.*/
             tags:
               only: # whatever tagged binary crates
-                - /^(interledger-settlement-engines-|v).*$/
+                - /^(ilp-settlement-ethereum-|v).*$/
           requires:
             - build
       - release-binaries:
@@ -277,7 +281,7 @@ workflows:
                 - /.*/
             tags:
               only: # whatever tagged binary crates
-                - /^(interledger-settlement-engines-|v).*$/
+                - /^(ilp-settlement-ethereum-|v).*$/
           requires:
             - build-release-binary-linux
             - build-release-binary-darwin

--- a/.circleci/release/build_musl_binary.sh
+++ b/.circleci/release/build_musl_binary.sh
@@ -26,10 +26,10 @@ docker run -dt --name builder "${docker_image_name}"
 
 docker cp ./Cargo.toml builder:/usr/src/Cargo.toml
 docker cp ./Cargo.lock builder:/usr/src/Cargo.lock
-docker cp ./src builder:/usr/src/src
+docker cp ./crates builder:/usr/src/crates
 
 # "--workdir" requires API version 1.35, but the Docker daemon API version of CircleCI is 1.32
-docker exec builder "/bin/bash" "-c" "cd /usr/src && cargo build --release --features \"ethereum\" --package \"${crate_name}\" --bin \"${crate_name}\" --target x86_64-unknown-linux-musl"
+docker exec builder "/bin/bash" "-c" "cd /usr/src && cargo build --release --package \"${crate_name}\" --bin \"${crate_name}\" --target x86_64-unknown-linux-musl"
 docker cp "builder:/usr/src/target/x86_64-unknown-linux-musl/release/${crate_name}" "${artifacts_path}"
 
 docker stop builder

--- a/.circleci/release/get_crate_name.sh
+++ b/.circleci/release/get_crate_name.sh
@@ -6,8 +6,6 @@
 # The regex means "(something)-(semantic version)"
 if [[ $1 =~ ^(.*)-v([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+[0-9A-Za-z-]+)?$ ]]; then
     echo ${BASH_REMATCH[1]}
-elif [[ $1 =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+[0-9A-Za-z-]+)?$ ]]; then
-    echo "interledger-settlement-engines"
-elif [[ $1 =~ ^interledger-settlement-engines-.*$ ]]; then
-    echo "interledger-settlement-engines"
+elif [[ $1 =~ ^ilp-settlement-ethereum-.*$ ]]; then
+    echo "ilp-settlement-ethereum"
 fi

--- a/.circleci/release/get_docker_image_tag.sh
+++ b/.circleci/release/get_docker_image_tag.sh
@@ -8,13 +8,13 @@
 # If no tag is given, it is considered as a `latest` (or possibly could be said `nightly`) build.
 # This script requires `jq`
 
-crate_name=$1 # currently not used, just make it consistent with `interledger-rs`
+crate_name=$1 # the name of the crate directory, not the name of the package written in Cargo.toml
 git_tag=$2
 
 if [ -n "$git_tag" ]; then
     # If it is a tag of semantic version expression
     if [[ "$git_tag" =~ ^.*v([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+[0-9A-Za-z-]+)?$ ]] ; then
-        cargo read-manifest --manifest-path Cargo.toml | jq -r .version
+        cargo read-manifest --manifest-path crates/${crate_name}/Cargo.toml | jq -r .version
     else
         printf "$git_tag"
     fi

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -17,7 +17,7 @@ fi
 
 if [ $# -eq 0 ]; then
     printf "\e[33mNo build target is given, building all targets.\e[m\n"
-    build_targets+=(settlement-engines)
+    build_targets+=(ilp-settlement-ethereum)
 fi
 
 # if arguments are given, add it as build targets
@@ -25,7 +25,7 @@ build_targets+=($@)
 
 for build_target in "${build_targets[@]}"; do
     case $build_target in
-        "settlement-engines") docker build -f ./docker/settlement-engines.dockerfile -t interledgerrs/settlement-engines:${docker_image_tag} \
+        "ilp-settlement-ethereum") docker build -f ./docker/ilp-settlement-ethereum.dockerfile -t interledgerrs/ilp-settlement-ethereum:${docker_image_tag} \
                 --build-arg CARGO_BUILD_OPTION="${CARGO_BUILD_OPTION}" \
                 --build-arg RUST_BIN_DIR_NAME="${RUST_BIN_DIR_NAME}" \
                 . ;;

--- a/docker/ilp-settlement-ethereum.dockerfile
+++ b/docker/ilp-settlement-ethereum.dockerfile
@@ -8,9 +8,9 @@ RUN echo "Building profile: ${CARGO_BUILD_OPTION}, output dir: ${RUST_BIN_DIR_NA
 WORKDIR /usr/src
 COPY ./Cargo.toml /usr/src/Cargo.toml
 COPY ./Cargo.lock /usr/src/Cargo.lock
-COPY ./src /usr/src/src
+COPY ./crates /usr/src/crates
 
-RUN cargo build ${CARGO_BUILD_OPTION} --features "ethereum" --package interledger-settlement-engines --bin interledger-settlement-engines
+RUN cargo build ${CARGO_BUILD_OPTION} --package ilp-settlement-ethereum --bin ilp-settlement-ethereum
 
 # Deploy compiled binary to another container
 FROM alpine
@@ -26,13 +26,13 @@ RUN apk --no-cache add ca-certificates
 
 # Copy binary
 COPY --from=rust \
-    /usr/src/target/x86_64-unknown-linux-musl/${RUST_BIN_DIR_NAME}/interledger-settlement-engines \
-    /usr/local/bin/interledger-settlement-engines
+    /usr/src/target/x86_64-unknown-linux-musl/${RUST_BIN_DIR_NAME}/ilp-settlement-ethereum \
+    /usr/local/bin/ilp-settlement-ethereum
 
 WORKDIR /opt/app
 
 # ENV RUST_BACKTRACE=1
 ENV RUST_LOG=interledger=debug
 
-ENTRYPOINT [ "/usr/local/bin/interledger-settlement-engines" ]
-CMD [ "ethereum-ledger" ]
+ENTRYPOINT [ "/usr/local/bin/ilp-settlement-ethereum" ]
+CMD [ ]


### PR DESCRIPTION
Fix: #21

Build docker images of `ilp-settlement-ethereum`, and build binaries of `ilp-settlement-ethereum`.